### PR TITLE
Add debian-archive-keyring to requirements

### DIFF
--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -5,6 +5,7 @@ build-essential
 chrpath
 clang-11
 curl
+debian-archive-keyring
 debootstrap
 fakeroot
 flex


### PR DESCRIPTION
The installation of DriFuzz on an Ubuntu 20.04 failed due to missing keys during debootstrap. This PR adds debian-archive-keyring to debian_requirements.txt, which solved the issue at least on my machine, running `Ubuntu 20.04.4 LTS`.

I did not test whether this breaks building on actual debian systems.